### PR TITLE
refactor: use clap for args and better format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,3 +5,240 @@ version = 4
 [[package]]
 name = "GLoftBinExtractor"
 version = "0.1.0"
+dependencies = [
+ "clap",
+]
+
+[[package]]
+name = "anstream"
+version = "0.6.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys",
+]
+
+[[package]]
+name = "clap"
+version = "4.5.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40b6887a1d8685cebccf115538db5c0efe625ccac9696ad45c409d96566e910f"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0c66c08ce9f0c698cbce5c0279d0bb6ac936d8674174fe48f736533b964f59e"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2c7947ae4cc3d851207c1adb5b5e260ff0cca11446b1d6d1423788e442257ce"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "syn"
+version = "2.0.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,4 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+clap = { version = "4.5.40", features = ["derive"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ use std::path::Path;
 use clap::Parser;
 
 #[derive(Parser, Debug)]
-#[command(version, about, long_about = None)]
+#[command(version)]
 struct Args {
     input_paths: Vec<String>,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,17 +1,25 @@
+use std::env;
 use std::fs::{self, File};
 use std::io::{Read, Write};
 use std::path::Path;
-use std::env;
+
+use clap::Parser;
+
+#[derive(Parser, Debug)]
+#[command(version, about, long_about = None)]
+struct Args {
+    input_paths: Vec<String>,
+}
 
 fn validate_input(args: &[String]) -> Result<Vec<String>, String> {
     if args.len() != 2 {
         return Err(format!("Usage: {} <input_path>", args[0]));
     }
     let input_path = Path::new(&args[1]);
-    
+
     if input_path.is_dir() {
         let bin_files: Vec<String> = fs::read_dir(input_path)
-            .map_err(|e| format!("Failed to read directory: {}", e))?
+            .map_err(|e| format!("Failed to read directory: {e}"))?
             .filter_map(|entry| {
                 let path = entry.ok()?.path();
                 if path.is_file() && path.extension().and_then(|s| s.to_str()) == Some("bin") {
@@ -21,7 +29,7 @@ fn validate_input(args: &[String]) -> Result<Vec<String>, String> {
                 }
             })
             .collect();
-        
+
         if bin_files.is_empty() {
             return Err("No .bin files found in directory".to_string());
         }
@@ -35,14 +43,13 @@ fn validate_input(args: &[String]) -> Result<Vec<String>, String> {
 }
 
 fn read_and_validate_file(path: &str, delimiter: &[u8]) -> Result<Vec<u8>, String> {
-    let mut file = File::open(path)
-        .map_err(|e| format!("Failed to open file {}: {}", path, e))?;
+    let mut file = File::open(path).map_err(|e| format!("Failed to open file {path}: {e}"))?;
     let mut buffer = Vec::new();
     file.read_to_end(&mut buffer)
-        .map_err(|e| format!("Failed to read file {}: {}", path, e))?;
+        .map_err(|e| format!("Failed to read file {path}: {e}"))?;
 
     if buffer.len() < delimiter.len() || buffer[0..delimiter.len()] != *delimiter {
-        return Err(format!("File {} does not start with valid delimiter", path));
+        return Err(format!("File {path} does not start with valid delimiter"));
     }
     Ok(buffer)
 }
@@ -89,7 +96,7 @@ fn process_chunk(chunk: &[u8], output_dir: &str) -> Result<(), String> {
             .map_err(|e| format!("Failed to create directory {}: {}", parent.display(), e))?;
     }
 
-    println!("filename: {}, buffer: {}", filename, buffer_size);
+    println!("filename: {filename}, buffer: {buffer_size}");
     let mut output_file = File::create(&output_path)
         .map_err(|e| format!("Failed to create file {}: {}", output_path.display(), e))?;
     output_file
@@ -100,17 +107,19 @@ fn process_chunk(chunk: &[u8], output_dir: &str) -> Result<(), String> {
 }
 
 fn process_file(input_path: &str, delimiter: &[u8]) -> Result<(), String> {
-    let output_dir = Path::new("Output")
-        .join(Path::new(&input_path)
+    let output_dir = Path::new("Output").join(
+        Path::new(&input_path)
             .file_stem()
             .and_then(|s| s.to_str())
             .map(|s| s.to_string())
-            .unwrap_or("output".to_string()));
-    let output_dir = output_dir.to_str()
-        .ok_or_else(|| format!("Invalid output directory path for {}", input_path))?;
-    
-    fs::create_dir_all(&output_dir)
-        .map_err(|e| format!("Failed to create output directory {}: {}", output_dir, e))?;
+            .unwrap_or("output".to_string()),
+    );
+    let output_dir = output_dir
+        .to_str()
+        .ok_or_else(|| format!("Invalid output directory path for {input_path}"))?;
+
+    fs::create_dir_all(output_dir)
+        .map_err(|e| format!("Failed to create output directory {output_dir}: {e}"))?;
 
     let buffer = read_and_validate_file(input_path, delimiter)?;
 
@@ -126,14 +135,15 @@ fn process_file(input_path: &str, delimiter: &[u8]) -> Result<(), String> {
 fn main() -> Result<(), String> {
     let args: Vec<String> = env::args().collect();
     let delimiter = [0x47, 0x42, 0x4D, 0x50];
+    let args = Args::parse_from(args);
 
-    let input_paths = validate_input(&args)?;
+    let input_paths = validate_input(&args.input_paths)?;
 
     for input_path in input_paths {
-        println!("Processing file: {}", input_path);
+        println!("Processing file: {input_path}");
         if let Err(e) = process_file(&input_path, &delimiter) {
-            eprintln!("Error processing file {}: {}", input_path, e);
-            continue; 
+            eprintln!("Error processing file {input_path}: {e}");
+            continue;
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,7 +19,7 @@ fn validate_input(args: &[String]) -> Result<Vec<String>, String> {
 
     if input_path.is_dir() {
         let bin_files: Vec<String> = fs::read_dir(input_path)
-            .map_err(|e| format!("Failed to read directory: {e}"))?
+            .map_err(|e| format!("Failed to read directory {}: {e}", input_path.display()))?
             .filter_map(|entry| {
                 let path = entry.ok()?.path();
                 if path.is_file() && path.extension().and_then(|s| s.to_str()) == Some("bin") {


### PR DESCRIPTION
This pull request introduces several improvements to the `src/main.rs` file, including the integration of the `clap` library for argument parsing, enhanced error formatting using inline placeholders, and refactoring of the `process_file` function for better readability. Additionally, the `Cargo.toml` file has been updated to include the new dependency.

### Integration of `clap` for argument parsing:
* Added the `clap` dependency with the `derive` feature in `Cargo.toml` (`[Cargo.tomlR7](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R7)`).
* Introduced the `Args` struct with `clap`'s `derive` macros to handle command-line arguments, replacing manual argument parsing (`[[1]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR1-R12)`, `[[2]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR138-R145)`).

### Enhanced error formatting:
* Updated error messages across various functions to use Rust's inline formatting syntax (e.g., `{variable}`) for improved readability and maintainability:
  - `validate_input` function (`[src/main.rsL14-R22](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL14-R22)`).
  - `read_and_validate_file` function (`[src/main.rsL38-R52](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL38-R52)`).
  - `process_chunk` function (`[src/main.rsL92-R99](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL92-R99)`).
  - `process_file` function (`[[1]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL103-R122)`, `[[2]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR138-R145)`).

### Refactoring of `process_file`:
* Simplified the construction of the `output_dir` path by streamlining the logic and improving error handling (`[src/main.rsL103-R122](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL103-R122)`).